### PR TITLE
Compatibility fix for Sliding Panes plugin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ export default class MaximiseActivePanePlugin extends PluginBase {
       callback: () => {
         // simply toggle the 'maximised' class and let the css do its thing
         this.rootSplit.containerEl.toggleClass('maximised', !this.rootSplit.containerEl.hasClass('maximised'));
+        this.app.workspace.onLayoutChange();
       }
     });
   }


### PR DESCRIPTION
If you create additional panes while maximized, and have the sliding panes plugin installed, the layout will be incorrect on de-maximizing.  This change ensures that plugins that need to know about changes in pane size (such as sliding panes) are told of the change.

(I didn't intentionally change the file-ending line feed bit, apparently that's Github's editor.  For developing this change, I just edited the built JS in my plugins/ folder, this is the translation back to TypeScript.  :wink: )