### PR TITLE
Solves maximising issues

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,11 @@ export default class MaximiseActivePanePlugin extends PluginBase {
       callback: () => {
         // simply toggle the 'maximised' class and let the css do its thing
         this.rootSplit.containerEl.toggleClass('maximised', !this.rootSplit.containerEl.hasClass('maximised'));
-        let i = _this.app.workspace.activeLeaf.containerEl.parentNode;
-        for (i = this.app.activeLeaf.containerEl.parentNode; i != this.rootSplit.containerEl ; i = i.parentNode) {
-        i.toggleClass('maximisedparentsplit', !i.hasClass('maximisedparentsplit'));
+        if (this.app.workspace.activeLeaf) {
+          let i = this.app.workspace.activeLeaf.containerEl.parentNode;
+          for (; i != this.rootSplit.containerEl ; i = i.parentNode) {
+          i.toggleClass('maximisedparentsplit', !i.hasClass('maximisedparentsplit'));
+          };
         };
         this.app.workspace.onLayoutChange();
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ export default class MaximiseActivePanePlugin extends PluginBase {
       callback: () => {
         // simply toggle the 'maximised' class and let the css do its thing
         this.rootSplit.containerEl.toggleClass('maximised', !this.rootSplit.containerEl.hasClass('maximised'));
+        this.app.workspace.activeLeaf.containerEl.parentNode.toggleClass('maximisedparentsplit', !this.app.workspace.activeLeaf.containerEl.parentNode.hasClass('maximisedparentsplit'));
         this.app.workspace.onLayoutChange();
       }
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,10 @@ export default class MaximiseActivePanePlugin extends PluginBase {
       callback: () => {
         // simply toggle the 'maximised' class and let the css do its thing
         this.rootSplit.containerEl.toggleClass('maximised', !this.rootSplit.containerEl.hasClass('maximised'));
-        this.app.workspace.activeLeaf.containerEl.parentNode.toggleClass('maximisedparentsplit', !this.app.workspace.activeLeaf.containerEl.parentNode.hasClass('maximisedparentsplit'));
+        let i = _this.app.workspace.activeLeaf.containerEl.parentNode;
+        for (i = this.app.activeLeaf.containerEl.parentNode; i != this.rootSplit.containerEl ; i = i.parentNode) {
+        i.toggleClass('maximisedparentsplit', !i.hasClass('maximisedparentsplit'));
+        };
         this.app.workspace.onLayoutChange();
       }
     });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,6 @@
 .plugin-maximise-active-pane {
   .workspace-split.maximised .workspace-leaf:not(.mod-active),
-  .workspace-split.maximised .workspace-leaf.mod-active~.workspace-split {
+  .workspace-split.maximised .workspace-split:not(.maximisedparentsplit) {
     display: none;
   }
   .workspace-split.maximised .workspace-leaf.mod-active {


### PR DESCRIPTION
Fix for [this issue](https://github.com/deathau/maximise-active-pane-obsidian/issues/10).

List of changes: 
https://github.com/gitobsidiantutorial/maximise-active-pane-obsidian/blob/main/src/main.ts#L29 When the command is called, a loop is executed, toggling the `maximisedparentsplit` class for the parent of the active leaf, and the parent of that split, etc., until the root split is reached. To prevent crashes and infinite loops, a check for the `activeleaf` existing is performed.

https://github.com/gitobsidiantutorial/maximise-active-pane-obsidian/blob/main/src/styles.scss#L3 The class which was toggled above is now targeted with CSS. No matter how deeply nested the active leaf is within splits, it now correctly maximised.


[Demo](https://user-images.githubusercontent.com/81381984/116126518-06ef9780-a6c7-11eb-841f-bd6cc8d925b2.mp4)

